### PR TITLE
chore: add comment about issue 2963

### DIFF
--- a/test/WrappedTests.t.sol
+++ b/test/WrappedTests.t.sol
@@ -73,6 +73,8 @@ contract BoundedInvariants is Basic4626InvariantBase {
         excludeContract(address(asset));
         excludeContract(address(token));
 
+        // We need this to avoid reverts due to EIP-3607
+        // See https://github.com/foundry-rs/foundry/issues/2963
         targetSender(address(0x1234));
     }
 


### PR DESCRIPTION
Was dabbling in invariant tests for the first time, and I ended up spending an hour debugging a revert which turned out to be due to this bug in Foundry https://github.com/foundry-rs/foundry/issues/2963 (and EIP-3067).

Looks like using `targetSender` fixes this - it would be nice to have a comment that explains why that function is needed (and add a reference to the Foundry bug).