### PR TITLE
refactor: remove "targetSender"

### DIFF
--- a/test/WrappedTests.t.sol
+++ b/test/WrappedTests.t.sol
@@ -72,8 +72,6 @@ contract BoundedInvariants is Basic4626InvariantBase {
 
         excludeContract(address(asset));
         excludeContract(address(token));
-
-        targetSender(address(0x1234));
     }
 
     function invariant_A() external { assert_invariant_A(); }
@@ -115,8 +113,6 @@ contract UnboundedInvariants is Basic4626InvariantBase {
 
         excludeContract(address(asset));
         excludeContract(address(token));
-
-        targetSender(address(0x1234));
     }
 
     function invariant_A() external { assert_invariant_A(); }
@@ -147,8 +143,6 @@ contract OpenInvariants is Basic4626InvariantBase {
         asset = new MockERC20("Asset", "ASSET", 18);
 
         token = new Basic4626Deposit(address(asset), "Token", "TOKEN", 18);
-
-        targetSender(address(0x1234));
     }
 
     function invariant_A() external { assert_invariant_A(); }


### PR DESCRIPTION
https://github.com/foundry-rs/foundry/pull/4181 has been merged, so we no longer need the calls to `targetSender`.

**Update**: as explained [here](https://github.com/foundry-rs/foundry/issues/2963#issuecomment-1406292397), we shouldn't merge this just yet. Looks like the fix isn't working as I expected.